### PR TITLE
Use chunk function to scan the document.

### DIFF
--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {user} from '../../../../src/log';
-
+import {ChunkPriority, chunk} from '../../../../src/chunk';
 import {EVENTS, ORIGINAL_URL_ATTRIBUTE} from './constants';
 import {LinkReplacementCache} from './link-replacement-cache';
 import {Observable} from '../../../../src/observable';
 import {TwoStepsResponse} from './two-steps-response';
+import {user} from '../../../../src/log';
 
 
 /** @typedef {!Array<{anchor: !HTMLElement, replacementUrl: ?string}>}} */
@@ -150,10 +150,15 @@ export class LinkRewriter {
    * @public
    */
   onDomUpdated() {
-    return this.scanLinksOnPage_().then(() => {
-      this.events.fire({
-        type: EVENTS.PAGE_SCANNED,
+    return new Promise(resolve => {
+      const task = (() => {
+        return this.scanLinksOnPage_().then(() => {
+          this.events.fire({type: EVENTS.PAGE_SCANNED});
+          resolve();
+        });
       });
+
+      chunk(this.rootNode_, task, ChunkPriority.LOW);
     });
   }
 

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -17,6 +17,7 @@
 import * as DocumentReady from '../../../../src/document-ready';
 import * as SkimOptionsModule from '../skim-options';
 import * as Utils from '../utils';
+import * as chunkModule from '../../../../src/chunk';
 import {Deferred} from '../../../../src/utils/promise';
 import {LinkRewriterManager} from '../link-rewriter/link-rewriter-manager';
 import {SKIMLINKS_REWRITER_ID} from '../constants';
@@ -132,6 +133,11 @@ describes.fakeWin(
 
             env.sandbox.stub(ampSkimlinks, 'onClick_');
             env.sandbox.stub(ampSkimlinks, 'onPageScanned_');
+            // Chunk executes the provided task when the browser is Idle. We can
+            // execute the task straight away for the purpose of the test.
+            env.sandbox.stub(chunkModule, 'chunk').callsFake((node, task) => {
+              task();
+            });
             linkRewriter = ampSkimlinks.initSkimlinksLinkRewriter_();
           });
 

--- a/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as chunkModule from '../../../../src/chunk';
 import {AmpEvents} from '../../../../src/amp-events';
 import {LinkReplacementCache} from '../link-rewriter/link-replacement-cache';
 import {LinkRewriter} from '../link-rewriter/link-rewriter';
@@ -37,6 +38,11 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, env => {
     env.sandbox.spy(rootDocument, 'addEventListener');
     env.sandbox.spy(rootDocument, 'querySelector');
 
+    // Chunk executes the provided task when the browser is Idle. We can
+    // execute the task straight away for the purpose of the test.
+    env.sandbox.stub(chunkModule, 'chunk').callsFake((node, task) => {
+      task();
+    });
     linkRewriterManager = new LinkRewriterManager(env.ampdoc);
 
     // Helper functions
@@ -409,6 +415,11 @@ describes.fakeWin('Link Rewriter', {amp: true}, env => {
   let createResolveResponseHelper, createLinkRewriterHelper;
 
   beforeEach(() => {
+    // Chunk executes the provided task when the browser is Idle. We can
+    // execute the task straight away for the purpose of the test.
+    env.sandbox.stub(chunkModule, 'chunk').callsFake((node, task) => {
+      task();
+    });
     rootDocument = env.ampdoc.getRootNode();
 
     createResolveResponseHelper = (syncData, asyncData) => {


### PR DESCRIPTION
Chunk will delay the execution of the document scanning to when the browser is idle. The purpose of this change is to avoid any potential performance issue that could affect the user experience when loading the page.

At this point, it hasn't been proven that amp-skimlinks could create such slowdown but it feels safer to wrap it inside the chunk function for now. Since this is not the ideal solution (we could potentially lose clicks and page impressions), it would be great to make more measurement and optimization and remove it once we feel confident that amp-skimlinks can run without risking to interfere with the user experience.