### PR TITLE
Amp skimlinks e2e tests

### DIFF
--- a/extensions/amp-skimlinks/0.1/affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/affiliate-link-resolver.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {DOMAIN_RESOLVER_API_URL} from './constants';
 import {TwoStepsResponse} from './link-rewriter/two-steps-response';
 import {dict} from '../../../src/utils/object';
 import {getNormalizedHostnameFromAnchor, isExcludedDomain} from './utils';
@@ -96,8 +95,8 @@ export class AffiliateLinkResolver {
       'page': '',
       'domains': domains,
     });
-
-    const beaconUrl = `${DOMAIN_RESOLVER_API_URL}?data=${JSON.stringify(data)}`;
+    let {beaconUrl} = this.skimOptions_.config;
+    beaconUrl = `${beaconUrl}?data=${JSON.stringify(data)}`;
     const fetchOptions = {
       method: 'GET',
       // Disabling AMP CORS since API does not support it.

--- a/extensions/amp-skimlinks/0.1/amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/amp-skimlinks.js
@@ -100,6 +100,7 @@ export class AmpSkimlinks extends AMP.BaseElement {
     this.waypoint_ = new Waypoint(
         /** @type {!../../../src/service/ampdoc-impl.AmpDoc} */
         (this.ampDoc_),
+        this.skimOptions_,
         this.trackingService_,
         this.referrer_
     );

--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -29,6 +29,14 @@ const LINKS_IMPRESSIONS_TRACKING_URL =
 const NA_CLICK_TRACKING_URL =
     `${TRACKING_API_URL}/?call=track&rnd=\${rnd}&data=\${data}`;
 
+export const DEFAULT_CONFIG = {
+  pageTrackingUrl: PAGE_IMPRESSION_TRACKING_URL,
+  linksTrackingUrl: LINKS_IMPRESSIONS_TRACKING_URL,
+  nonAffiliateTrackingUrl: NA_CLICK_TRACKING_URL,
+  waypointUrl: AFFILIATION_API,
+  beaconUrl: DOMAIN_RESOLVER_API_URL,
+};
+
 // Domains excluded from impressions & affiliation & NA click tracking.
 export const GLOBAL_DOMAIN_BLACKLIST = [
   'facebook.com',
@@ -39,11 +47,12 @@ export const GLOBAL_DOMAIN_BLACKLIST = [
   'youtube.com',
 ];
 
-export const DEFAULT_CONFIG = {
-  pageTrackingUrl: PAGE_IMPRESSION_TRACKING_URL,
-  linksTrackingUrl: LINKS_IMPRESSIONS_TRACKING_URL,
-  nonAffiliateTrackingUrl: NA_CLICK_TRACKING_URL,
-  waypointUrl: AFFILIATION_API,
-  beaconUrl: DOMAIN_RESOLVER_API_URL,
+export const OPTIONS_ERRORS = {
+  INVALID_PUBCODE: '"publisher-code" is required.',
+  INVALID_XCUST:
+    '"custom-tracking-id" should be <=50 characters and only contain upper ' +
+    'and lowercase characters, numbers, underscores and pipes.',
+  INVALID_TRACKING_STATUS: '"tracking" possible values are "true" or "false".',
 };
+
 

--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -20,13 +20,13 @@ export const AFFILIATION_API = 'https://go.skimresources.com';
 export const PLATFORM_NAME = 'amp@' + AMP_SKIMLINKS_VERSION;
 export const SKIMLINKS_REWRITER_ID = 'amp-skimlinks';
 
-export const DOMAIN_RESOLVER_API_URL = 'https://r.skimresources.com/api';
-export const TRACKING_API_URL = 'https://t.skimresources.com/api';
-export const PAGE_IMPRESSION_TRACKING_URL =
+const DOMAIN_RESOLVER_API_URL = 'https://r.skimresources.com/api';
+const TRACKING_API_URL = 'https://t.skimresources.com/api';
+const PAGE_IMPRESSION_TRACKING_URL =
     `${TRACKING_API_URL}/track.php?data=\${data}`;
-export const LINKS_IMPRESSIONS_TRACKING_URL =
+const LINKS_IMPRESSIONS_TRACKING_URL =
     `${TRACKING_API_URL}/link?data=\${data}`;
-export const NA_CLICK_TRACKING_URL =
+const NA_CLICK_TRACKING_URL =
     `${TRACKING_API_URL}/?call=track&rnd=\${rnd}&data=\${data}`;
 
 // Domains excluded from impressions & affiliation & NA click tracking.
@@ -38,3 +38,12 @@ export const GLOBAL_DOMAIN_BLACKLIST = [
   'twitter.com',
   'youtube.com',
 ];
+
+export const DEFAULT_CONFIG = {
+  pageTrackingUrl: PAGE_IMPRESSION_TRACKING_URL,
+  linksTrackingUrl: LINKS_IMPRESSIONS_TRACKING_URL,
+  nonAffiliateTrackingUrl: NA_CLICK_TRACKING_URL,
+  waypointUrl: AFFILIATION_API,
+  beaconUrl: DOMAIN_RESOLVER_API_URL,
+};
+

--- a/extensions/amp-skimlinks/0.1/constants.js
+++ b/extensions/amp-skimlinks/0.1/constants.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const AMP_SKIMLINKS_VERSION = '1.0.1';
+export const AMP_SKIMLINKS_VERSION = '1.0.2';
 export const XCUST_ATTRIBUTE_NAME = 'data-skimlinks-custom-tracking-id';
 export const AFFILIATION_API = 'https://go.skimresources.com';
 export const PLATFORM_NAME = 'amp@' + AMP_SKIMLINKS_VERSION;

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -20,6 +20,7 @@ import {userAssert} from '../../../src/log';
 
 import {
   AFFILIATION_API,
+  DOMAIN_RESOLVER_API_URL,
   GLOBAL_DOMAIN_BLACKLIST,
   LINKS_IMPRESSIONS_TRACKING_URL,
   NA_CLICK_TRACKING_URL,
@@ -39,6 +40,7 @@ export const defaultConfig = {
   'linksTrackingUrl': LINKS_IMPRESSIONS_TRACKING_URL,
   'nonAffiliateTrackingUrl': NA_CLICK_TRACKING_URL,
   'waypointUrl': AFFILIATION_API,
+  'beaconUrl': DOMAIN_RESOLVER_API_URL,
 };
 
 /**

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -169,10 +169,7 @@ function getInternalDomains_(docInfo) {
  */
 function getConfig_(element) {
   try {
-    return {
-      ...defaultConfig,
-      ...getChildJsonConfig(element),
-    };
+    return Object.assign({}, defaultConfig, getChildJsonConfig(element));
   } catch (err) {
     return defaultConfig;
   }

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import {GLOBAL_DOMAIN_BLACKLIST} from './constants';
+import {getChildJsonConfig} from '../../../src/json';
 import {getNormalizedHostnameFromUrl} from './utils';
 import {userAssert} from '../../../src/log';
+
+import {
+  GLOBAL_DOMAIN_BLACKLIST,
+  LINKS_IMPRESSIONS_TRACKING_URL,
+  NA_CLICK_TRACKING_URL,
+  PAGE_IMPRESSION_TRACKING_URL,
+} from './constants';
 
 const errors = {
   INVALID_PUBCODE: '"publisher-code" is required.',
@@ -48,6 +55,7 @@ export function getAmpSkimlinksOptions(element, docInfo) {
     tracking: getTrackingStatus_(element),
     customTrackingId: getCustomTrackingId_(element),
     linkSelector: getLinkSelector_(element),
+    config: getConfig_(element),
   };
 }
 
@@ -145,4 +153,23 @@ function getInternalDomains_(docInfo) {
   }
 
   return internalDomains;
+}
+
+
+/**
+ * @param {!Element} element
+ */
+function getConfig_(element) {
+  const defaultConfig = {
+    'pageTrackingUrl': PAGE_IMPRESSION_TRACKING_URL,
+  };
+
+  try {
+    return {
+      ...defaultConfig,
+      ...getChildJsonConfig(element),
+    };
+  } catch (err) {
+    return defaultConfig;
+  }
 }

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -19,12 +19,8 @@ import {getNormalizedHostnameFromUrl} from './utils';
 import {userAssert} from '../../../src/log';
 
 import {
-  AFFILIATION_API,
-  DOMAIN_RESOLVER_API_URL,
+  DEFAULT_CONFIG,
   GLOBAL_DOMAIN_BLACKLIST,
-  LINKS_IMPRESSIONS_TRACKING_URL,
-  NA_CLICK_TRACKING_URL,
-  PAGE_IMPRESSION_TRACKING_URL,
 } from './constants';
 
 const errors = {
@@ -35,13 +31,7 @@ const errors = {
   INVALID_TRACKING_STATUS: '"tracking" possible values are "true" or "false".',
 };
 
-export const defaultConfig = {
-  'pageTrackingUrl': PAGE_IMPRESSION_TRACKING_URL,
-  'linksTrackingUrl': LINKS_IMPRESSIONS_TRACKING_URL,
-  'nonAffiliateTrackingUrl': NA_CLICK_TRACKING_URL,
-  'waypointUrl': AFFILIATION_API,
-  'beaconUrl': DOMAIN_RESOLVER_API_URL,
-};
+
 
 /**
  *
@@ -167,11 +157,29 @@ function getInternalDomains_(docInfo) {
 
 /**
  * @param {!Element} element
+ * @return {!Object}
  */
 function getConfig_(element) {
   try {
-    return Object.assign({}, defaultConfig, getChildJsonConfig(element));
+    // Custom config is only used for e2e tests.
+    const customConfigJson = getChildJsonConfig(element);
+    // Warning: getChildJsonConfig returns an JSON object while
+    // DEFAULT_CONFIG is a normal object with keys that can be renamed
+    // by google closure compiler on the production build. Therefore, we
+    // are converting here the JSON object keys to the internal object keys.
+    return {
+      pageTrackingUrl: customConfigJson['pageTrackingUrl'] ||
+        DEFAULT_CONFIG.pageTrackingUrl,
+      linksTrackingUrl: customConfigJson['linksTrackingUrl'] ||
+        DEFAULT_CONFIG.linksTrackingUrl,
+      nonAffiliateTrackingUrl: customConfigJson['nonAffiliateTrackingUrl'] ||
+        DEFAULT_CONFIG.nonAffiliateTrackingUrl,
+      waypointUrl: customConfigJson['waypointUrl'] ||
+        DEFAULT_CONFIG.waypointUrl,
+      beaconUrl: customConfigJson['beaconUrl'] ||
+        DEFAULT_CONFIG.beaconUrl,
+    };
   } catch (err) {
-    return defaultConfig;
+    return DEFAULT_CONFIG;
   }
 }

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -21,17 +21,8 @@ import {userAssert} from '../../../src/log';
 import {
   DEFAULT_CONFIG,
   GLOBAL_DOMAIN_BLACKLIST,
+  OPTIONS_ERRORS,
 } from './constants';
-
-const errors = {
-  INVALID_PUBCODE: '"publisher-code" is required.',
-  INVALID_XCUST:
-    '"custom-tracking-id" should be <=50 characters and only contain upper ' +
-    'and lowercase characters, numbers, underscores and pipes.',
-  INVALID_TRACKING_STATUS: '"tracking" possible values are "true" or "false".',
-};
-
-
 
 /**
  *
@@ -63,6 +54,7 @@ export function getAmpSkimlinksOptions(element, docInfo) {
  *
  * @param {!Element} element
  * @param {!Array<string>} internalDomains
+ * @return {!Array<string>}
  */
 function getExcludedDomains_(element, internalDomains) {
   let excludedDomains = []
@@ -89,7 +81,7 @@ function getExcludedDomains_(element, internalDomains) {
  */
 function getPubCode_(element) {
   const pubCode = element.getAttribute('publisher-code');
-  assertSkimOption(pubCode, errors.INVALID_PUBCODE);
+  assertSkimOption(pubCode, OPTIONS_ERRORS.INVALID_PUBCODE);
 
   return pubCode;
 }
@@ -103,7 +95,7 @@ function getTrackingStatus_(element) {
   const tracking = element.getAttribute('tracking');
   if (tracking) {
     const isValidValue = tracking === 'true' || tracking === 'false';
-    assertSkimOption(isValidValue, errors.INVALID_TRACKING_STATUS);
+    assertSkimOption(isValidValue, OPTIONS_ERRORS.INVALID_TRACKING_STATUS);
     return tracking === 'true';
   }
 
@@ -120,7 +112,7 @@ function getCustomTrackingId_(element) {
   if (customTrackingId) {
     // TODO: Check for alphanumerical + [_|] only.
     const isValidXcust = customTrackingId.length <= 50;
-    assertSkimOption(isValidXcust, errors.INVALID_XCUST);
+    assertSkimOption(isValidXcust, OPTIONS_ERRORS.INVALID_XCUST);
   }
 
   return customTrackingId;

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -19,6 +19,7 @@ import {getNormalizedHostnameFromUrl} from './utils';
 import {userAssert} from '../../../src/log';
 
 import {
+  AFFILIATION_API,
   GLOBAL_DOMAIN_BLACKLIST,
   LINKS_IMPRESSIONS_TRACKING_URL,
   NA_CLICK_TRACKING_URL,
@@ -31,6 +32,13 @@ const errors = {
     '"custom-tracking-id" should be <=50 characters and only contain upper ' +
     'and lowercase characters, numbers, underscores and pipes.',
   INVALID_TRACKING_STATUS: '"tracking" possible values are "true" or "false".',
+};
+
+export const defaultConfig = {
+  'pageTrackingUrl': PAGE_IMPRESSION_TRACKING_URL,
+  'linksTrackingUrl': LINKS_IMPRESSIONS_TRACKING_URL,
+  'nonAffiliateTrackingUrl': NA_CLICK_TRACKING_URL,
+  'waypointUrl': AFFILIATION_API,
 };
 
 /**
@@ -160,10 +168,6 @@ function getInternalDomains_(docInfo) {
  * @param {!Element} element
  */
 function getConfig_(element) {
-  const defaultConfig = {
-    'pageTrackingUrl': PAGE_IMPRESSION_TRACKING_URL,
-  };
-
   try {
     return {
       ...defaultConfig,

--- a/extensions/amp-skimlinks/0.1/skim-options.js
+++ b/extensions/amp-skimlinks/0.1/skim-options.js
@@ -165,7 +165,6 @@ function getInternalDomains_(docInfo) {
   return internalDomains;
 }
 
-
 /**
  * @param {!Element} element
  */

--- a/extensions/amp-skimlinks/0.1/test/helpers.js
+++ b/extensions/amp-skimlinks/0.1/test/helpers.js
@@ -18,6 +18,7 @@ import {AmpSkimlinks} from '../amp-skimlinks';
 import {CustomEventReporterBuilder} from '../../../../src/extension-analytics';
 import {Services} from '../../../../src/services';
 import {Tracking} from '../tracking';
+import {defaultConfig} from '../skim-options';
 import {pubcode} from './constants';
 
 const helpersFactory = env => {
@@ -61,6 +62,7 @@ const helpersFactory = env => {
           {
             tracking: true,
             pubcode,
+            config: defaultConfig,
           },
           skimOptions
       );

--- a/extensions/amp-skimlinks/0.1/test/helpers.js
+++ b/extensions/amp-skimlinks/0.1/test/helpers.js
@@ -16,9 +16,9 @@
 
 import {AmpSkimlinks} from '../amp-skimlinks';
 import {CustomEventReporterBuilder} from '../../../../src/extension-analytics';
+import {DEFAULT_CONFIG} from '../constants';
 import {Services} from '../../../../src/services';
 import {Tracking} from '../tracking';
-import {defaultConfig} from '../skim-options';
 import {pubcode} from './constants';
 
 const helpersFactory = env => {
@@ -62,7 +62,7 @@ const helpersFactory = env => {
           {
             tracking: true,
             pubcode,
-            config: defaultConfig,
+            config: DEFAULT_CONFIG,
           },
           skimOptions
       );

--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -207,7 +207,11 @@ describes.fakeWin(
         describe('Does correct request to domain resolver API', () => {
           beforeEach(() => {
             mock = env.sandbox.mock(xhr);
-            resolver = new AffiliateLinkResolver(xhr, {pubcode}, waypoint);
+            const skimOptions = {
+              pubcode,
+              config: {beaconUrl: DOMAIN_RESOLVER_API_URL},
+            };
+            resolver = new AffiliateLinkResolver(xhr, skimOptions, waypoint);
           });
 
           afterEach(() => {
@@ -281,9 +285,13 @@ describes.fakeWin(
             const stubXhr = helpers.createStubXhr({
               'merchant_domains': ['merchant1.com', 'merchant2.com'],
             });
+            const skimOptions = {
+              excludedDomains: ['excluded-merchant.com'],
+              config: {beaconUrl: DOMAIN_RESOLVER_API_URL},
+            };
             resolver = new AffiliateLinkResolver(
                 stubXhr,
-                {excludedDomains: ['excluded-merchant.com']},
+                skimOptions,
                 waypoint
             );
           });
@@ -414,7 +422,8 @@ describes.fakeWin(
         });
 
         describe('getAnchorDomain_', () => {
-          const resolver = new AffiliateLinkResolver({}, {}, waypoint);
+          const skimOptions = {config: {beaconUrl: DOMAIN_RESOLVER_API_URL}};
+          const resolver = new AffiliateLinkResolver({}, skimOptions, waypoint);
 
           it('Removes  http protocol', () => {
             const anchor = helpers.createAnchor('http://test.com');

--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -46,7 +46,15 @@ describes.fakeWin(
 
       beforeEach(() => {
         trackingService = helpers.createTrackingWithStubAnalytics();
-        waypoint = new Waypoint(env.ampdoc, trackingService, 'referrer');
+        const skimOptions = {
+          config: {waypointUrl: 'https://go.skimresources.com/'},
+        };
+        waypoint = new Waypoint(
+            env.ampdoc,
+            skimOptions,
+            trackingService,
+            'referrer'
+        );
       });
 
       afterEach(() => {

--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -18,11 +18,13 @@ import {
   AFFILIATE_STATUS,
   AffiliateLinkResolver,
 } from '../affiliate-link-resolver';
-import {DOMAIN_RESOLVER_API_URL} from '../constants';
+import {DEFAULT_CONFIG} from '../constants';
 import {Services} from '../../../../src/services';
 import {Waypoint} from '../waypoint';
 import {pubcode} from './constants';
 import helpersFactory from './helpers';
+
+const DOMAIN_RESOLVER_API_URL = DEFAULT_CONFIG.beaconUrl;
 
 describes.fakeWin(
     'AffiliateLinkResolver',

--- a/extensions/amp-skimlinks/0.1/test/test-tracking.js
+++ b/extensions/amp-skimlinks/0.1/test/test-tracking.js
@@ -19,12 +19,17 @@ import {pubcode} from './constants';
 import helpersFactory from './helpers';
 
 import {
-  LINKS_IMPRESSIONS_TRACKING_URL,
-  NA_CLICK_TRACKING_URL,
-  PAGE_IMPRESSION_TRACKING_URL,
+  DEFAULT_CONFIG,
   PLATFORM_NAME,
   XCUST_ATTRIBUTE_NAME,
 } from '../constants';
+
+
+const {
+  pageTrackingUrl: PAGE_IMPRESSION_TRACKING_URL,
+  linksTrackingUrl: LINKS_IMPRESSIONS_TRACKING_URL,
+  nonAffiliateTrackingUrl: NA_CLICK_TRACKING_URL,
+} = DEFAULT_CONFIG;
 
 describes.fakeWin(
     'test-tracking',

--- a/extensions/amp-skimlinks/0.1/test/test-waypoint.js
+++ b/extensions/amp-skimlinks/0.1/test/test-waypoint.js
@@ -60,7 +60,15 @@ describes.fakeWin(
           canonicalUrl: 'canonical_url',
         });
         env.sandbox.stub(Date.prototype, 'getTimezoneOffset').returns('-120');
-        waypoint = new Waypoint(env.ampdoc, trackingService, 'referrer_url');
+        const skimOptions = {
+          config: {waypointUrl: 'https://go.skimresources.com/'},
+        };
+        waypoint = new Waypoint(
+            env.ampdoc,
+            skimOptions,
+            trackingService,
+            'referrer_url'
+        );
       });
 
       afterEach(() => {

--- a/extensions/amp-skimlinks/0.1/tracking.js
+++ b/extensions/amp-skimlinks/0.1/tracking.js
@@ -19,8 +19,6 @@ import {dict} from '../../../src/utils/object';
 import {generatePageImpressionId, isExcludedAnchorUrl} from './utils';
 
 import {
-  LINKS_IMPRESSIONS_TRACKING_URL,
-  NA_CLICK_TRACKING_URL,
   PLATFORM_NAME,
   XCUST_ATTRIBUTE_NAME,
 } from './constants';
@@ -236,15 +234,20 @@ export class Tracking {
    */
   setupAnalytics_(element) {
     const analyticsBuilder = new CustomEventReporterBuilder(element);
-    const pageImpressionUrl = this.skimOptions_.config.pageTrackingUrl;
+    const {
+      pageTrackingUrl,
+      linksTrackingUrl,
+      nonAffiliateTrackingUrl,
+    } = this.skimOptions_.config;
+
     // Configure analytics to send POST request when receiving
     // 'page-impressions' event.
     analyticsBuilder.track(PAGE_IMPRESSIONS,
-        pageImpressionUrl);
+        pageTrackingUrl);
     analyticsBuilder.track(LINK_IMPRESSIONS,
-        LINKS_IMPRESSIONS_TRACKING_URL);
+        linksTrackingUrl);
     analyticsBuilder.track(NON_AFFILIATE_CLICK,
-        NA_CLICK_TRACKING_URL);
+        nonAffiliateTrackingUrl);
 
     analyticsBuilder.setTransportConfig(dict({
       'beacon': true,

--- a/extensions/amp-skimlinks/0.1/tracking.js
+++ b/extensions/amp-skimlinks/0.1/tracking.js
@@ -19,10 +19,8 @@ import {dict} from '../../../src/utils/object';
 import {generatePageImpressionId, isExcludedAnchorUrl} from './utils';
 
 import {
-
   LINKS_IMPRESSIONS_TRACKING_URL,
   NA_CLICK_TRACKING_URL,
-  PAGE_IMPRESSION_TRACKING_URL,
   PLATFORM_NAME,
   XCUST_ATTRIBUTE_NAME,
 } from './constants';
@@ -238,10 +236,11 @@ export class Tracking {
    */
   setupAnalytics_(element) {
     const analyticsBuilder = new CustomEventReporterBuilder(element);
+    const pageImpressionUrl = this.skimOptions_.config.pageTrackingUrl;
     // Configure analytics to send POST request when receiving
     // 'page-impressions' event.
     analyticsBuilder.track(PAGE_IMPRESSIONS,
-        PAGE_IMPRESSION_TRACKING_URL);
+        pageImpressionUrl);
     analyticsBuilder.track(LINK_IMPRESSIONS,
         LINKS_IMPRESSIONS_TRACKING_URL);
     analyticsBuilder.track(NON_AFFILIATE_CLICK,

--- a/extensions/amp-skimlinks/0.1/tracking.js
+++ b/extensions/amp-skimlinks/0.1/tracking.js
@@ -158,7 +158,8 @@ export class Tracking {
     });
 
     // Sends POST request. Second param is the object used to interpolate
-    // placeholder variables defined in NA_CLICK_TRACKING_URL.
+    // placeholder variables defined in NA_CLICK_TRACKING_URL
+    // (See constants.js).
     this.analytics_.trigger(NON_AFFILIATE_CLICK, dict({
       'data': JSON.stringify(data),
       'rnd': 'RANDOM',
@@ -187,7 +188,8 @@ export class Tracking {
     ));
 
     // Sends POST request. Second param is the object used to interpolate
-    // placeholder variables defined in PAGE_IMPRESSION_TRACKING_URL.
+    // placeholder variables defined in PAGE_IMPRESSION_TRACKING_URL
+    // (See constants.js).
     this.analytics_.trigger(PAGE_IMPRESSIONS, dict({
       'data': JSON.stringify(data),
     }));
@@ -218,6 +220,7 @@ export class Tracking {
 
     // Send POST request. Second param is the object used to interpolate
     // placeholder variables defined in LINKS_IMPRESSIONS_TRACKING_URL.
+    // (See constants.js).
     this.analytics_.trigger(LINK_IMPRESSIONS, dict({
       'data': JSON.stringify(data),
     }));

--- a/extensions/amp-skimlinks/0.1/waypoint.js
+++ b/extensions/amp-skimlinks/0.1/waypoint.js
@@ -15,7 +15,6 @@
  */
 
 import {
-  AFFILIATION_API,
   PLATFORM_NAME,
   XCUST_ATTRIBUTE_NAME,
 } from './constants';
@@ -31,10 +30,11 @@ import {dict} from '../../../src/utils/object';
 export class Waypoint {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Object} skimOptions
    * @param {!./tracking.Tracking} tracking
    * @param {string} referrer
    */
-  constructor(ampdoc, tracking, referrer) {
+  constructor(ampdoc, skimOptions, tracking, referrer) {
     /** @private {?./tracking.Tracking} */
     this.tracking_ = tracking;
 
@@ -46,6 +46,9 @@ export class Waypoint {
 
     /** @private {string} */
     this.timezone_ = `${new Date().getTimezoneOffset()}`;
+
+    /** @private {!Object} */
+    this.skimOptions_ = skimOptions;
   }
 
   /**
@@ -82,7 +85,7 @@ export class Waypoint {
     if (xcust) {
       queryParams['xcust'] = xcust;
     }
-
-    return addParamsToUrl(AFFILIATION_API, /** @type {!JsonObject} */ (queryParams));
+    const affiliationUrl = this.skimOptions_.config.waypointUrl;
+    return addParamsToUrl(affiliationUrl, /** @type {!JsonObject} */ (queryParams));
   }
 }

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -13,12 +13,11 @@ const nonAffiliateTrackingUrl = RequestBank.getUrl('nonAffiliateTrackingUrl') +
   '?call=track&data=${data}';
 const waypointUrl = `${RequestBank.getUrl('waypointUrl')}`;
 
-
 // Simulated click event created by browser.click() does not trigger
 // the browser navigation when dispatched on a link.
 // Using MouseEvent("click") instead of Event("click") does,
-// which is what we need for those tests.
-function clickLink_(doc, selector) {
+// which is what we need for some tests.
+function clickLinkAndNavigate_(doc, selector) {
   const element = doc.querySelector(selector);
   if (element) {
     const clickEvent = new MouseEvent('click', {bubbles: true});
@@ -26,9 +25,11 @@ function clickLink_(doc, selector) {
   }
 }
 
-const setupBasic = {
-  extensions: ['amp-skimlinks'],
-  body: `
+
+describe('amp-skimlinks', function() {
+  const setupBasic = {
+    extensions: ['amp-skimlinks'],
+    body: `
     <amp-skimlinks
         layout="nodisplay"
         publisher-code="123X123"
@@ -48,31 +49,15 @@ const setupBasic = {
         <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
     </div>
   `,
-};
-
-const setupNoConfig = {
-  extensions: ['amp-skimlinks'],
-  body: `
-      <amp-skimlinks
-          layout="nodisplay"
-          publisher-code="123X123"
-          tracking="true"
-      >
-      </amp-skimlinks>
-      <div>
-          <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
-          <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
-      </div>
-  `,
-};
-
-describe('amp-skimlinks', function() {
+  };
   describes.integration('Basic features', setupBasic, env => {
     let browser = null;
-    let clickLink = null;
+    let clickLinkAndNavigate = null;
 
     beforeEach(() => {
-      clickLink = selector => clickLink_(env.win.document, selector);
+      clickLinkAndNavigate = selector => {
+        return clickLinkAndNavigate_(env.win.document, selector);
+      };
       browser = new BrowserController(env.win);
       return browser.waitForElementBuild('amp-skimlinks');
     });
@@ -117,7 +102,7 @@ describe('amp-skimlinks', function() {
     it('Should send NA-tracking on non-merchant link click ', () => {
       // Give 500ms for amp-skimlinks to set up
       return browser.wait(500).then(() => {
-        clickLink('#non-merchant-link');
+        clickLinkAndNavigate('#non-merchant-link');
 
         return RequestBank.withdraw('nonAffiliateTrackingUrl').then(req => {
           const regex = /^\/\?call=track&data=([^&]*)&?.*$/;
@@ -133,10 +118,10 @@ describe('amp-skimlinks', function() {
       });
     });
 
-    it('Should send to waypoint on merchant link click', () => {
+    it('Should send merchant links to waypoint on click', () => {
       // Give 500ms for amp-skimlinks to set up
       return browser.wait(500).then(() => {
-        clickLink('#merchant-link');
+        clickLinkAndNavigate('#merchant-link');
         return RequestBank.withdraw('waypointUrl').then(req => {
           // Remove "/?..." in the url
           const queryString = req.url.slice(2);
@@ -154,6 +139,21 @@ describe('amp-skimlinks', function() {
   });
 
 
+  const setupNoConfig = {
+    extensions: ['amp-skimlinks'],
+    body: `
+      <amp-skimlinks
+          layout="nodisplay"
+          publisher-code="123X123"
+          tracking="true"
+      >
+      </amp-skimlinks>
+      <div>
+          <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
+          <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
+      </div>
+  `,
+  };
   // The purpose of these tests is to make sure that amp-skimlinks still
   // works when the JSON config necessary to run our tests is not
   // injected (similar to live environment).
@@ -161,19 +161,17 @@ describe('amp-skimlinks', function() {
   // therefore can only test a small subset of features.
   describes.integration('Works without test config', setupNoConfig, env => {
     let browser = null;
-    let clickLink = null;
 
     beforeEach(() => {
-      clickLink = selector => clickLink_(env.win.document, selector);
       browser = new BrowserController(env.win);
       return browser.waitForElementBuild('amp-skimlinks');
     });
 
 
-    it('Should send to waypoint on merchant link click', () => {
+    it('Should send merchant links to to waypoint on click', () => {
       // Give 500ms for amp-skimlinks to set up
       return browser.wait(500).then(() => {
-        clickLink('#merchant-link');
+        browser.click('#merchant-link');
         const link = env.win.document.querySelector('#merchant-link');
         const regex = /^https\:\/\/go\.skimresources\.com\/\?(.*)$/;
         const match = regex.exec(link.href);
@@ -189,5 +187,57 @@ describe('amp-skimlinks', function() {
       });
     });
   });
+});
 
+
+const setupUnknownLinks = {
+  extensions: ['amp-skimlinks'],
+  body: `
+      <amp-skimlinks
+          layout="nodisplay"
+          publisher-code="123X123"
+          tracking="true"
+      >
+        <script type="application/json">
+          {
+              "beaconUrl": "http://deelay.me/2000/fakeBeacon"
+          }
+        </script>
+      </amp-skimlinks>
+      <div>
+          <a id="unknown-link" href="https://google.com"> Test unknown link </a>
+      </div>
+  `,
+};
+describes.integration('Affiliate unknown links', setupUnknownLinks, env => {
+  let browser = null;
+
+  beforeEach(() => {
+    browser = new BrowserController(env.win);
+    return browser.waitForElementBuild('amp-skimlinks');
+  });
+
+
+  it('Should send unknown links to waypoint', () => {
+    // Give 500ms for amp-skimlinks to set up
+    return browser.wait(500).then(() => {
+      // beacon API url has been overwritten by a deelay.me URL that will keep
+      // the request pending during 2s. When the click happens, beacon API has
+      // not come back yet with affiliated domain information and the link is
+      // still considered as unknown.
+      browser.click('#unknown-link');
+      const link = env.win.document.querySelector('#unknown-link');
+      const regex = /^https\:\/\/go\.skimresources\.com\/\?(.*)$/;
+      const match = regex.exec(link.href);
+      expect(match).to.be.lengthOf(2);
+      const queryParams = parseQueryString(match[1]);
+      expect(queryParams.id).to.equal('123X123');
+      expect(queryParams.jv).to.equal(PLATFORM_NAME);
+      expect(queryParams.xuuid).to.have.lengthOf(32);
+      expect(queryParams.url).to.equal('https://google.com/');
+      expect(queryParams.sref).to.equal('http://nonblocking.io/');
+      expect(queryParams.pref).to.have.lengthOf.above(1);
+      expect(queryParams.xs).to.equal('1');
+    });
+  });
 });

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -2,6 +2,9 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {PLATFORM_NAME} from '../../extensions/amp-skimlinks/0.1/constants';
 import {parseQueryString} from '../../src/url';
 
+// Create fake test urls to replace skimlinks API urls.
+// RequestBank allow us to check if an API request has been made
+// or not by calling RequestBank.withdraw later.
 const pageTrackingUrl = RequestBank.getUrl('pageTrackingUrl') +
   '/track.php?data=${data}';
 const linksTrackingUrl = RequestBank.getUrl('linksTrackingUrl') +
@@ -10,50 +13,68 @@ const nonAffiliateTrackingUrl = RequestBank.getUrl('nonAffiliateTrackingUrl') +
   '?call=track&data=${data}';
 const waypointUrl = `${RequestBank.getUrl('waypointUrl')}`;
 
-describe('amp-skimlinks', function() {
-  const setup = {
-    extensions: ['amp-skimlinks'],
-    body: `
-            <amp-skimlinks
-                layout="nodisplay"
-                publisher-code="123X123"
-                tracking="true"
-            >
-              <script type="application/json">
-                {
-                    "pageTrackingUrl": "${pageTrackingUrl}",
-                    "linksTrackingUrl": "${linksTrackingUrl}",
-                    "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}",
-                    "waypointUrl": "${waypointUrl}"
-                }
-              </script>
-            </amp-skimlinks>
-            <div>
-                <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
-                <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
-            </div>
-        `,
-  };
 
-  describes.integration('Basic page', setup, env => {
+// Simulated click event created by browser.click() does not trigger
+// the browser navigation when dispatched on a link.
+// Using MouseEvent("click") instead of Event("click") does,
+// which is what we need for those tests.
+function clickLink_(doc, selector) {
+  const element = doc.querySelector(selector);
+  if (element) {
+    const clickEvent = new MouseEvent('click', {bubbles: true});
+    element.dispatchEvent(clickEvent);
+  }
+}
+
+const setupBasic = {
+  extensions: ['amp-skimlinks'],
+  body: `
+    <amp-skimlinks
+        layout="nodisplay"
+        publisher-code="123X123"
+        tracking="true"
+    >
+      <script type="application/json">
+        {
+            "pageTrackingUrl": "${pageTrackingUrl}",
+            "linksTrackingUrl": "${linksTrackingUrl}",
+            "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}",
+            "waypointUrl": "${waypointUrl}"
+        }
+      </script>
+    </amp-skimlinks>
+    <div>
+        <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
+        <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
+    </div>
+  `,
+};
+
+const setupNoConfig = {
+  extensions: ['amp-skimlinks'],
+  body: `
+      <amp-skimlinks
+          layout="nodisplay"
+          publisher-code="123X123"
+          tracking="true"
+      >
+      </amp-skimlinks>
+      <div>
+          <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
+          <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
+      </div>
+  `,
+};
+
+describe('amp-skimlinks', function() {
+  describes.integration('Basic features', setupBasic, env => {
     let browser = null;
     let clickLink = null;
 
     beforeEach(() => {
-      // Simulated click event created by browser.click() does not trigger
-      // the browser navigation when dispatched on a link.
-      // Using MouseEvent("click") instead of Event("click") does,
-      // which is what we want in those tests.
-      clickLink = selector => {
-        const element = env.win.document.querySelector(selector);
-        if (element) {
-          const clickEvent = new MouseEvent('click', {bubbles: true});
-          element.dispatchEvent(clickEvent);
-        }
-      };
+      clickLink = selector => clickLink_(env.win.document, selector);
       browser = new BrowserController(env.win);
       return browser.waitForElementBuild('amp-skimlinks');
-
     });
 
     it('Should send the page impression tracking request', () => {
@@ -94,9 +115,9 @@ describe('amp-skimlinks', function() {
     });
 
     it('Should send NA-tracking on non-merchant link click ', () => {
-      // Give 500ms for amp-skimlinks to setup
+      // Give 500ms for amp-skimlinks to set up
       return browser.wait(500).then(() => {
-        clickLink('a#non-merchant-link');
+        clickLink('#non-merchant-link');
 
         return RequestBank.withdraw('nonAffiliateTrackingUrl').then(req => {
           const regex = /^\/\?call=track&data=([^&]*)&?.*$/;
@@ -113,9 +134,9 @@ describe('amp-skimlinks', function() {
     });
 
     it('Should send to waypoint on merchant link click', () => {
-      // Give 500ms for amp-skimlinks to setup
+      // Give 500ms for amp-skimlinks to set up
       return browser.wait(500).then(() => {
-        clickLink('a#merchant-link');
+        clickLink('#merchant-link');
         return RequestBank.withdraw('waypointUrl').then(req => {
           // Remove "/?..." in the url
           const queryString = req.url.slice(2);
@@ -131,4 +152,42 @@ describe('amp-skimlinks', function() {
       });
     });
   });
+
+
+  // The purpose of these tests is to make sure that amp-skimlinks still
+  // works when the JSON config necessary to run our tests is not
+  // injected (similar to live environment).
+  // Since the JSON config is not set we can not use the proxy and
+  // therefore can only test a small subset of features.
+  describes.integration('Works without test config', setupNoConfig, env => {
+    let browser = null;
+    let clickLink = null;
+
+    beforeEach(() => {
+      clickLink = selector => clickLink_(env.win.document, selector);
+      browser = new BrowserController(env.win);
+      return browser.waitForElementBuild('amp-skimlinks');
+    });
+
+
+    it('Should send to waypoint on merchant link click', () => {
+      // Give 500ms for amp-skimlinks to set up
+      return browser.wait(500).then(() => {
+        clickLink('#merchant-link');
+        const link = env.win.document.querySelector('#merchant-link');
+        const regex = /^https\:\/\/go\.skimresources\.com\/\?(.*)$/;
+        const match = regex.exec(link.href);
+        expect(match).to.be.lengthOf(2);
+        const queryParams = parseQueryString(match[1]);
+        expect(queryParams.id).to.equal('123X123');
+        expect(queryParams.jv).to.equal(PLATFORM_NAME);
+        expect(queryParams.xuuid).to.have.lengthOf(32);
+        expect(queryParams.url).to.equal('https://nordstrom.com/');
+        expect(queryParams.sref).to.equal('http://nonblocking.io/');
+        expect(queryParams.pref).to.have.lengthOf.above(1);
+        expect(queryParams.xs).to.equal('1');
+      });
+    });
+  });
+
 });

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -93,7 +93,6 @@ describe('amp-skimlinks', function() {
         expect(data.hae).to.equal(1);
         expect(data.dl).to.deep.equal({
           'https://nordstrom.com/': {count: 1, ae: 1},
-          'https://google.com/': {count: 1, ae: 0},
         });
       });
     });
@@ -185,56 +184,58 @@ describe('amp-skimlinks', function() {
       });
     });
   });
-});
 
 
-const setupUnknownLinks = {
-  extensions: ['amp-skimlinks'],
-  body: `
-      <amp-skimlinks
-          layout="nodisplay"
-          publisher-code="123X123"
-          tracking="true"
-      >
-        <script type="application/json">
-          {
-              "beaconUrl": "http://deelay.me/2000/fakeBeacon"
-          }
-        </script>
-      </amp-skimlinks>
-      <div>
-          <a id="unknown-link" href="https://google.com"> Test unknown link </a>
-      </div>
-  `,
-};
-describes.integration('Affiliate unknown links', setupUnknownLinks, env => {
-  let browser = null;
+  const setupUnknownLinks = {
+    extensions: ['amp-skimlinks'],
+    body: `
+        <amp-skimlinks
+            layout="nodisplay"
+            publisher-code="123X123"
+            tracking="true"
+        >
+          <script type="application/json">
+            {
+                "beaconUrl": "http://deelay.me/2000/fakeBeacon"
+            }
+          </script>
+        </amp-skimlinks>
+        <div>
+            <a id="unknown-link" href="https://google.com"> Test unknown link </a>
+        </div>
+    `,
+  };
+  describes.integration('Affiliate unknown links', setupUnknownLinks, env => {
+    let browser = null;
 
-  beforeEach(() => {
-    browser = new BrowserController(env.win);
-    return browser.waitForElementBuild('amp-skimlinks');
-  });
+    beforeEach(() => {
+      browser = new BrowserController(env.win);
+      return browser.waitForElementBuild('amp-skimlinks');
+    });
 
-  it('Should send unknown links to waypoint', () => {
-    // Give 500ms for amp-skimlinks to set up.
-    return browser.wait(500).then(() => {
-      // beacon API url has been overwritten by a deelay.me URL that will keep
-      // the request pending during 2s. When the click happens, beacon API has
-      // not come back yet with affiliated domain information and the link is
-      // still considered as unknown.
-      browser.click('#unknown-link');
-      const link = env.win.document.querySelector('#unknown-link');
-      const regex = /^https\:\/\/go\.skimresources\.com\/\?(.*)$/;
-      const match = regex.exec(link.href);
-      expect(match).to.be.lengthOf(2);
-      const queryParams = parseQueryString(match[1]);
-      expect(queryParams.id).to.equal('123X123');
-      expect(queryParams.jv).to.equal(PLATFORM_NAME);
-      expect(queryParams.xuuid).to.have.lengthOf(32);
-      expect(queryParams.url).to.equal('https://google.com/');
-      expect(queryParams.sref).to.equal('http://nonblocking.io/');
-      expect(queryParams.pref).to.have.lengthOf.above(1);
-      expect(queryParams.xs).to.equal('1');
+    it('Should send unknown links to waypoint', () => {
+      // Give 500ms for amp-skimlinks to set up.
+      return browser.wait(500).then(() => {
+        // beacon API url has been overwritten by a deelay.me URL that will keep
+        // the request pending during 2s. When the click happens, beacon API has
+        // not come back yet with affiliated domain information and the link is
+        // still considered as unknown.
+        browser.click('#unknown-link');
+        const link = env.win.document.querySelector('#unknown-link');
+        const regex = /^https\:\/\/go\.skimresources\.com\/\?(.*)$/;
+        const match = regex.exec(link.href);
+        expect(match).to.be.lengthOf(2);
+        const queryParams = parseQueryString(match[1]);
+        expect(queryParams.id).to.equal('123X123');
+        expect(queryParams.jv).to.equal(PLATFORM_NAME);
+        expect(queryParams.xuuid).to.have.lengthOf(32);
+        expect(queryParams.url).to.equal('https://google.com/');
+        expect(queryParams.sref).to.equal('http://nonblocking.io/');
+        expect(queryParams.pref).to.have.lengthOf.above(1);
+        expect(queryParams.xs).to.equal('1');
+      });
     });
   });
 });
+
+

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {PLATFORM_NAME} from '../../extensions/amp-skimlinks/0.1/constants';
 import {parseQueryString} from '../../src/url';

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -1,6 +1,11 @@
 import {BrowserController, RequestBank} from '../../testing/test-helper';
+import {PLATFORM_NAME} from '../../extensions/amp-skimlinks/0.1/constants';
+import {parseQueryString} from '../../src/url';
 
 const pageTrackingUrl = `${RequestBank.getUrl('pageTrackingUrl')}/track.php?data=\${data}`;
+const linksTrackingUrl = `${RequestBank.getUrl('linksTrackingUrl')}/link?data=\${data}`;
+const nonAffiliateTrackingUrl = `${RequestBank.getUrl('nonAffiliateTrackingUrl')}?call=track&data=\${data}`;
+const waypointUrl = `${RequestBank.getUrl('waypointUrl')}`;
 
 describe('amp-skimlinks', function() {
   const setup = {
@@ -8,41 +13,118 @@ describe('amp-skimlinks', function() {
     body: `
             <amp-skimlinks
                 layout="nodisplay"
-                publisher-code="68019X1584676"
+                publisher-code="123X123"
                 tracking="true"
             >
               <script type="application/json">
                 {
-                    "pageTrackingUrl": "${pageTrackingUrl}"
+                    "pageTrackingUrl": "${pageTrackingUrl}",
+                    "linksTrackingUrl": "${linksTrackingUrl}",
+                    "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}",
+                    "waypointUrl": "${waypointUrl}"
                 }
               </script>
             </amp-skimlinks>
             <div>
-                <a id="merchant-link" href="https://nordstrom.com> Test Merchant </a>
+                <a id="merchant-link" href="https://nordstrom.com"> Test Merchant </a>
+                <a id="non-merchant-link" href="https://google.com"> Test non-Merchant </a>
             </div>
         `,
   };
 
-  describes.integration('test', setup, env => {
+  describes.integration('Basic page', setup, env => {
     let browser = null;
+    let clickLink = null;
 
     beforeEach(() => {
+      // Simulated click event created by browser.click() does not trigger
+      // the browser navigation when dispatched on a link.
+      // Using MouseEvent("click") instead of Event("click") does,
+      // which is what we want in those tests.
+      clickLink = selector => {
+        const element = env.win.document.querySelector(selector);
+        if (element) {
+          const clickEvent = new MouseEvent('click', {bubbles: true});
+          element.dispatchEvent(clickEvent);
+        }
+      };
       browser = new BrowserController(env.win);
       return browser.waitForElementBuild('amp-skimlinks');
+
     });
 
-    it('should test', () => {
+    it('Should send the page impression tracking request', () => {
       return RequestBank.withdraw('pageTrackingUrl').then(req => {
         const regex = /^\/track\.php\?data=([^&]*)&?.*$/;
         const match = regex.exec(req.url);
 
-        expect(match.length).to.equal(2);
+        expect(match).to.have.lengthOf(2);
         const data = JSON.parse(decodeURIComponent(match[1]));
-        expect(data.jv).to.equal('amp@1.0.0');
-        expect(data.pub).to.equal('68019X1584676');
+        expect(data.jv).to.equal(PLATFORM_NAME);
+        expect(data.pub).to.equal('123X123');
         // nonblocking.io is the default canonical url
         expect(data.pag).to.equal('http://nonblocking.io/');
-        expect(data.uuid.length).to.equal(32);
+        expect(data.uuid).to.have.lengthOf(32);
+
+      });
+    });
+
+    it('Should send the links impression tracking request', () => {
+      return RequestBank.withdraw('linksTrackingUrl').then(req => {
+        const regex = /^\/link\?data=([^&]*)&?.*$/;
+        const match = regex.exec(req.url);
+
+        expect(match).to.have.lengthOf(2);
+        const data = JSON.parse(decodeURIComponent(match[1]));
+        expect(data.jv).to.equal(PLATFORM_NAME);
+        expect(data.pub).to.equal('123X123');
+        // nonblocking.io is the default canonical url
+        expect(data.pag).to.equal('http://nonblocking.io/');
+        expect(data.uuid).to.have.lengthOf(32);
+
+        expect(data.hae).to.equal(1);
+        expect(data.dl).to.deep.equal({
+          'https://nordstrom.com/': {count: 1, ae: 1},
+          'https://google.com/': {count: 1, ae: 0},
+        });
+      });
+    });
+
+    it('Should send NA-tracking on non-merchant link click ', () => {
+      // Give 500ms for amp-skimlinks to setup
+      return browser.wait(500).then(() => {
+        clickLink('a#non-merchant-link');
+
+        return RequestBank.withdraw('nonAffiliateTrackingUrl').then(req => {
+          const regex = /^\/\?call=track&data=([^&]*)&?.*$/;
+          const match = regex.exec(req.url);
+          expect(match).to.have.lengthOf(2);
+          const data = JSON.parse(decodeURIComponent(match[1]));
+          expect(data.url).to.equal('https://google.com/');
+          expect(data.referrer).to.equal('http://nonblocking.io/');
+          expect(data.jv).to.equal(PLATFORM_NAME);
+          expect(data.uuid).to.have.lengthOf(32);
+          expect(data.pref).to.have.lengthOf.above(1);
+        });
+      });
+    });
+
+    it('Should send to waypoint on merchant link click', () => {
+      // Give 500ms for amp-skimlinks to setup
+      return browser.wait(500).then(() => {
+        clickLink('a#merchant-link');
+        return RequestBank.withdraw('waypointUrl').then(req => {
+          // Remove "/?..." in the url
+          const queryString = req.url.slice(2);
+          const queryParams = parseQueryString(queryString);
+          expect(queryParams.id).to.equal('123X123');
+          expect(queryParams.jv).to.equal(PLATFORM_NAME);
+          expect(queryParams.xuuid).to.have.lengthOf(32);
+          expect(queryParams.url).to.equal('https://nordstrom.com/');
+          expect(queryParams.sref).to.equal('http://nonblocking.io/');
+          expect(queryParams.pref).to.have.lengthOf.above(1);
+          expect(queryParams.xs).to.equal('1');
+        });
       });
     });
   });

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -25,7 +25,6 @@ function clickLinkAndNavigate_(doc, selector) {
   }
 }
 
-
 describe('amp-skimlinks', function() {
   const setupBasic = {
     extensions: ['amp-skimlinks'],
@@ -59,6 +58,7 @@ describe('amp-skimlinks', function() {
         return clickLinkAndNavigate_(env.win.document, selector);
       };
       browser = new BrowserController(env.win);
+
       return browser.waitForElementBuild('amp-skimlinks');
     });
 
@@ -71,10 +71,9 @@ describe('amp-skimlinks', function() {
         const data = JSON.parse(decodeURIComponent(match[1]));
         expect(data.jv).to.equal(PLATFORM_NAME);
         expect(data.pub).to.equal('123X123');
-        // nonblocking.io is the default canonical url
+        // nonblocking.io is the default canonical url.
         expect(data.pag).to.equal('http://nonblocking.io/');
         expect(data.uuid).to.have.lengthOf(32);
-
       });
     });
 
@@ -87,7 +86,7 @@ describe('amp-skimlinks', function() {
         const data = JSON.parse(decodeURIComponent(match[1]));
         expect(data.jv).to.equal(PLATFORM_NAME);
         expect(data.pub).to.equal('123X123');
-        // nonblocking.io is the default canonical url
+        // nonblocking.io is the default canonical url.
         expect(data.pag).to.equal('http://nonblocking.io/');
         expect(data.uuid).to.have.lengthOf(32);
 
@@ -100,7 +99,7 @@ describe('amp-skimlinks', function() {
     });
 
     it('Should send NA-tracking on non-merchant link click ', () => {
-      // Give 500ms for amp-skimlinks to set up
+      // Give 500ms for amp-skimlinks to set up.
       return browser.wait(500).then(() => {
         clickLinkAndNavigate('#non-merchant-link');
 
@@ -119,11 +118,11 @@ describe('amp-skimlinks', function() {
     });
 
     it('Should send merchant links to waypoint on click', () => {
-      // Give 500ms for amp-skimlinks to set up
+      // Give 500ms for amp-skimlinks to set up.
       return browser.wait(500).then(() => {
         clickLinkAndNavigate('#merchant-link');
         return RequestBank.withdraw('waypointUrl').then(req => {
-          // Remove "/?..." in the url
+          // Remove "/?" in the url.
           const queryString = req.url.slice(2);
           const queryParams = parseQueryString(queryString);
           expect(queryParams.id).to.equal('123X123');
@@ -167,9 +166,8 @@ describe('amp-skimlinks', function() {
       return browser.waitForElementBuild('amp-skimlinks');
     });
 
-
     it('Should send merchant links to to waypoint on click', () => {
-      // Give 500ms for amp-skimlinks to set up
+      // Give 500ms for amp-skimlinks to set up.
       return browser.wait(500).then(() => {
         browser.click('#merchant-link');
         const link = env.win.document.querySelector('#merchant-link');
@@ -217,9 +215,8 @@ describes.integration('Affiliate unknown links', setupUnknownLinks, env => {
     return browser.waitForElementBuild('amp-skimlinks');
   });
 
-
   it('Should send unknown links to waypoint', () => {
-    // Give 500ms for amp-skimlinks to set up
+    // Give 500ms for amp-skimlinks to set up.
     return browser.wait(500).then(() => {
       // beacon API url has been overwritten by a deelay.me URL that will keep
       // the request pending during 2s. When the click happens, beacon API has

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -1,0 +1,49 @@
+import {BrowserController, RequestBank} from '../../testing/test-helper';
+
+const pageTrackingUrl = `${RequestBank.getUrl('pageTrackingUrl')}/track.php?data=\${data}`;
+
+describe('amp-skimlinks', function() {
+  const setup = {
+    extensions: ['amp-skimlinks'],
+    body: `
+            <amp-skimlinks
+                layout="nodisplay"
+                publisher-code="68019X1584676"
+                tracking="true"
+            >
+              <script type="application/json">
+                {
+                    "pageTrackingUrl": "${pageTrackingUrl}"
+                }
+              </script>
+            </amp-skimlinks>
+            <div>
+                <a id="merchant-link" href="https://nordstrom.com> Test Merchant </a>
+            </div>
+        `,
+  };
+
+  describes.integration('test', setup, env => {
+    let browser = null;
+
+    beforeEach(() => {
+      browser = new BrowserController(env.win);
+      return browser.waitForElementBuild('amp-skimlinks');
+    });
+
+    it('should test', () => {
+      return RequestBank.withdraw('pageTrackingUrl').then(req => {
+        const regex = /^\/track\.php\?data=([^&]*)&?.*$/;
+        const match = regex.exec(req.url);
+
+        expect(match.length).to.equal(2);
+        const data = JSON.parse(decodeURIComponent(match[1]));
+        expect(data.jv).to.equal('amp@1.0.0');
+        expect(data.pub).to.equal('68019X1584676');
+        // nonblocking.io is the default canonical url
+        expect(data.pag).to.equal('http://nonblocking.io/');
+        expect(data.uuid.length).to.equal(32);
+      });
+    });
+  });
+});

--- a/test/integration/test-amp-skimlinks.js
+++ b/test/integration/test-amp-skimlinks.js
@@ -2,9 +2,12 @@ import {BrowserController, RequestBank} from '../../testing/test-helper';
 import {PLATFORM_NAME} from '../../extensions/amp-skimlinks/0.1/constants';
 import {parseQueryString} from '../../src/url';
 
-const pageTrackingUrl = `${RequestBank.getUrl('pageTrackingUrl')}/track.php?data=\${data}`;
-const linksTrackingUrl = `${RequestBank.getUrl('linksTrackingUrl')}/link?data=\${data}`;
-const nonAffiliateTrackingUrl = `${RequestBank.getUrl('nonAffiliateTrackingUrl')}?call=track&data=\${data}`;
+const pageTrackingUrl = RequestBank.getUrl('pageTrackingUrl') +
+  '/track.php?data=${data}';
+const linksTrackingUrl = RequestBank.getUrl('linksTrackingUrl') +
+  '/link?data=${data}';
+const nonAffiliateTrackingUrl = RequestBank.getUrl('nonAffiliateTrackingUrl') +
+  '?call=track&data=${data}';
 const waypointUrl = `${RequestBank.getUrl('waypointUrl')}`;
 
 describe('amp-skimlinks', function() {


### PR DESCRIPTION
In order to test amp-skimlinks script, I introduced a new **optional** JSON config to overwrite the request urls used by amp-skimlinks. The config can be inserted inside the `<amp-skimlinks>` tag as follow:

```html
<amp-skimlinks
    layout="nodisplay"
    publisher-code="123X123"
    tracking="true"
>
    <script type="application/json">
    {
        "pageTrackingUrl": "${pageTrackingUrl}",
        "linksTrackingUrl": "${linksTrackingUrl}",
        "nonAffiliateTrackingUrl": "${nonAffiliateTrackingUrl}",
        "waypointUrl": "${waypointUrl}"
    }
    </script>
</amp-skimlinks>
```

This allows us to redirect all the API calls to a proxy which helps us to validate if an API call has happened as expected or not.